### PR TITLE
Draft JVM target and read ByteArray for fs-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ subprojects {
         jcenter()
         google()
         maven { url "https://kotlin.bintray.com/kotlinx" }
-        maven { url "https://dl.bintray.com/suparnatural/kotlin-multiplatform" }
+        maven { url "https://dl.bintray.com/svendroid/kotlin-multiplatform" }
     }
 
     apply plugin: 'maven-publish'

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ subprojects {
     android {
         compileSdkVersion 28
         defaultConfig {
-            minSdkVersion 21
+            minSdkVersion 19
             targetSdkVersion 28
             versionCode 1
             versionName '1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.4.2'
     }
     ext.suparnatural_version = '1.0.2'
 }

--- a/fs-core/build.gradle
+++ b/fs-core/build.gradle
@@ -42,3 +42,10 @@ kotlin.sourceSets.jvmMain {
         implementation kotlin('stdlib')
     }
 }
+
+kotlin.sourceSets.jvmTest {
+    dependencies {
+        implementation kotlin('test')
+        implementation kotlin('test-junit')
+    }
+}

--- a/fs-core/build.gradle
+++ b/fs-core/build.gradle
@@ -13,7 +13,6 @@ kotlin.sourceSets.iosArm64Main {
 kotlin.sourceSets.commonMain {
     dependencies {
         implementation "com.suparnatural:utilities-core:$suparnatural_version"
-
     }
 }
 
@@ -31,3 +30,15 @@ kotlin.sourceSets.androidTest {
     }
 }
 
+kotlin {
+    sourceSets {
+        //only used for running unit tests in Android Studio easily
+        jvm('jvm')
+    }
+}
+
+kotlin.sourceSets.jvmMain {
+    dependencies {
+        implementation kotlin('stdlib')
+    }
+}

--- a/fs-core/src/androidMain/kotlin/com.suparnatural.core.fs/FileSystem.kt
+++ b/fs-core/src/androidMain/kotlin/com.suparnatural.core.fs/FileSystem.kt
@@ -49,8 +49,9 @@ actual object FileSystem {
     }
 
     actual fun readDir(path: String): List<StatResult>? {
-        val parent = File(path).canonicalFile
-        return parent.listFiles().map {
+        val parent = File(path).canonicalFile ?: return null
+        val fileList = parent.listFiles() ?: return null
+        return fileList.map {
             buildStats(it)
         }
     }

--- a/fs-core/src/androidMain/kotlin/com.suparnatural.core.fs/FileSystem.kt
+++ b/fs-core/src/androidMain/kotlin/com.suparnatural.core.fs/FileSystem.kt
@@ -2,7 +2,6 @@ package com.suparnatural.core.fs
 
 import android.content.Context
 import android.util.Base64
-import android.util.Log
 import java.io.*
 import java.util.concurrent.atomic.AtomicReference
 
@@ -97,6 +96,11 @@ actual object FileSystem {
     actual fun readFile(pathComponent: PathComponent, encoding: ContentEncoding): String? {
         val path = pathComponent.component ?: return null
         return readFile(path, encoding)
+    }
+
+    actual fun readFileAsByteArray(path: String): ByteArray? {
+        val file = File(path).canonicalFile
+        return file.readBytes()
     }
 
     private fun writeFile(path: String, contents: String, create: Boolean, encoding: ContentEncoding, append: Boolean = false): Boolean {

--- a/fs-core/src/androidMain/kotlin/com.suparnatural.core.fs/FileSystem.kt
+++ b/fs-core/src/androidMain/kotlin/com.suparnatural.core.fs/FileSystem.kt
@@ -103,6 +103,21 @@ actual object FileSystem {
         return file.readBytes()
     }
 
+    /**
+     * Writes `contents` to the file located at `path`. If `create` is true, then file is created if it does not exist.
+     * Returns true if operation is successful, otherwise false.
+     */
+    actual fun writeFile(path: String, contents: ByteArray, create: Boolean): Boolean {
+        val file = File(path).canonicalFile
+        if (!file.exists()) {
+            if (!create) return false
+            file.createNewFile()
+        }
+
+        FileOutputStream(file, false).write(contents)
+        return true
+    }
+
     private fun writeFile(path: String, contents: String, create: Boolean, encoding: ContentEncoding, append: Boolean = false): Boolean {
         val file = File(path).canonicalFile
         if (!file.exists()) {

--- a/fs-core/src/commonMain/kotlin/com/suparnatural/core/fs/FileSystem.kt
+++ b/fs-core/src/commonMain/kotlin/com/suparnatural/core/fs/FileSystem.kt
@@ -59,6 +59,8 @@ expect object FileSystem {
      */
     fun readFile(path: String, encoding: ContentEncoding = ContentEncoding.Utf8): String?
 
+    fun readFileAsByteArray(path: String):ByteArray?
+
     /**
      *
      * Returns the contents of the file located at `pathComponent`. The content is parsed according to `encoding`.

--- a/fs-core/src/commonMain/kotlin/com/suparnatural/core/fs/FileSystem.kt
+++ b/fs-core/src/commonMain/kotlin/com/suparnatural/core/fs/FileSystem.kt
@@ -71,6 +71,12 @@ expect object FileSystem {
 
     /**
      * Writes `contents` to the file located at `path`. If `create` is true, then file is created if it does not exist.
+     * Returns true if operation is successful, otherwise false.
+     */
+    fun writeFile(path: String, contents: ByteArray, create: Boolean = false): Boolean
+
+    /**
+     * Writes `contents` to the file located at `path`. If `create` is true, then file is created if it does not exist.
      * For binary files, use `encoding` = [ContentEncoding.Base64].
      * * Returns true if operation is successful, otherwise false.
      */

--- a/fs-core/src/commonTest/kotlin/com/suparnatural/core/fs/test.kt
+++ b/fs-core/src/commonTest/kotlin/com/suparnatural/core/fs/test.kt
@@ -23,7 +23,6 @@ class FileSystemTests {
         assertTrue(FileSystem.writeFile(testFilePath, testString, true))
     }
 
-
     @Test
     fun testKnownPaths() {
         assertNotNull(FileSystem.contentsDirectory)
@@ -38,9 +37,6 @@ class FileSystemTests {
             assertTrue(it.absolutePath!!.component!!.isNotEmpty())
             assertTrue(it.relativePath!!.component!!.isNotEmpty())
         }
-
-
-
     }
 
     @Test
@@ -102,6 +98,14 @@ class FileSystemTests {
         assertTrue(FileSystem.writeFile(testFilePath, testString, false, ContentEncoding.Base64))
         assertEquals(testBase64String, FileSystem.readFile(testFilePath, ContentEncoding.Utf8))
 
+    }
+
+    @ExperimentalStdlibApi
+    @Test
+    fun testWriteFileByteArray(){
+
+        assertTrue(FileSystem.writeFile(testFilePath.component!!, "HelloByteArray".encodeToByteArray(), true))
+        assertEquals("HelloByteArray", FileSystem.readFile(testFilePath, ContentEncoding.Utf8))
     }
 
     @Test

--- a/fs-core/src/iosMain/kotlin/com/suparnatural/core/fs/FileSystem.kt
+++ b/fs-core/src/iosMain/kotlin/com/suparnatural/core/fs/FileSystem.kt
@@ -149,6 +149,21 @@ actual object FileSystem {
 
     }
 
+    actual fun readFileAsByteArray(path: String): ByteArray? {
+        val url = Path.urlFromString(path)
+        val path = url?.standardizedURL?.path ?: return null
+        val data = manager.contentsAtPath(path) ?: return null
+        return nsDataToByteArray(data)
+
+    }
+
+    private fun nsDataToByteArray(data: NSData): ByteArray? {
+        if (data.bytes == null) {
+            return null
+        }
+        return data.bytes!!.readBytes(data.length.toInt())
+    }
+
     actual fun readFile(path: String, encoding: ContentEncoding): String? = readFile(Path.urlFromString(path), encoding)
     actual fun readFile(pathComponent: PathComponent, encoding: ContentEncoding): String? = readFile(pathComponent.url, encoding)
 

--- a/fs-core/src/jvmMain/kotlin/com/suparnatural/core/fs/FileSystem.kt
+++ b/fs-core/src/jvmMain/kotlin/com/suparnatural/core/fs/FileSystem.kt
@@ -95,6 +95,21 @@ actual object FileSystem {
         return readFile(path, encoding)
     }
 
+    /**
+     * Writes `contents` to the file located at `path`. If `create` is true, then file is created if it does not exist.
+     * Returns true if operation is successful, otherwise false.
+     */
+    actual fun writeFile(path: String, contents: ByteArray, create: Boolean): Boolean {
+        val file = File(path).canonicalFile
+        if (!file.exists()) {
+            if (!create) return false
+            file.createNewFile()
+        }
+
+        FileOutputStream(file, false).write(contents)
+        return true
+    }
+
     private fun writeFile(path: String, contents: String, create: Boolean, encoding: ContentEncoding, append: Boolean = false): Boolean {
         val file = File(path).canonicalFile
         if (!file.exists()) {

--- a/fs-core/src/jvmMain/kotlin/com/suparnatural/core/fs/FileSystem.kt
+++ b/fs-core/src/jvmMain/kotlin/com/suparnatural/core/fs/FileSystem.kt
@@ -8,7 +8,7 @@ actual object FileSystem {
 
     actual val contentsDirectory: Path
         get() {
-            val path = Paths.get("/").toAbsolutePath().toString()
+            val path = Paths.get("./contents/").toAbsolutePath().toString()
             File(path).mkdirs()
             return Path.simplified(path)
         }
@@ -16,7 +16,7 @@ actual object FileSystem {
 
     actual val cachesDirectory: Path
         get() {
-            val path = Paths.get("/caches/").toAbsolutePath().toString()
+            val path = Paths.get("./caches/").toAbsolutePath().toString()
             File(path).mkdirs()
             return Path.simplified(path)
         }

--- a/fs-core/src/jvmMain/kotlin/com/suparnatural/core/fs/FileSystem.kt
+++ b/fs-core/src/jvmMain/kotlin/com/suparnatural/core/fs/FileSystem.kt
@@ -1,0 +1,232 @@
+package com.suparnatural.core.fs
+
+import java.io.*
+import java.nio.file.Paths
+import java.util.*
+
+actual object FileSystem {
+
+    actual val contentsDirectory: Path
+        get() {
+            val path = Paths.get("/").toAbsolutePath().toString()
+            File(path).mkdirs()
+            return Path.simplified(path)
+        }
+
+
+    actual val cachesDirectory: Path
+        get() {
+            val path = Paths.get("/caches/").toAbsolutePath().toString()
+            File(path).mkdirs()
+            return Path.simplified(path)
+        }
+
+
+    actual val temporaryDirectory: Path
+        get() = cachesDirectory
+
+
+    private fun buildStats(file: File): StatResult {
+        val fileType = {
+            when {
+                file.isDirectory -> FileType.Directory
+                file.isFile -> FileType.Regular
+                else -> FileType.Unknown
+            }
+        }()
+        return StatResult(
+            name = file.name,
+            absolutePath = PathComponent(file.absolutePath),
+            canonicalPath = PathComponent(file.canonicalPath),
+            createdAt = 0.0,
+            modifiedAt = file.lastModified().toDouble(),
+            size = file.length().toDouble(),
+            type = fileType
+        )
+    }
+
+    actual fun readDir(path: String): List<StatResult>? {
+        val parent = File(path).canonicalFile
+        return parent.listFiles().map {
+            buildStats(it)
+        }
+    }
+
+
+    actual fun readDir(pathComponent: PathComponent): List<StatResult>? {
+        val path = pathComponent.component ?: return null
+        return readDir(path)
+    }
+
+
+    actual fun stat(path: String): StatResult? {
+        val file = File(path)
+        return buildStats(file)
+    }
+
+
+    actual fun stat(pathComponent: PathComponent): StatResult? {
+        val path = pathComponent.component ?: return null
+        return stat(path)
+    }
+
+
+    actual fun readFile(path: String, encoding: ContentEncoding): String? {
+        val file = File(path).canonicalFile
+
+        val charset = {
+            when (encoding) {
+                ContentEncoding.Ascii -> Charsets.US_ASCII
+                else -> Charsets.UTF_8
+            }
+        }()
+        val reader = BufferedReader(InputStreamReader(FileInputStream(file), charset))
+        val content = reader.readLines().joinToString("\n")
+
+        if (encoding == ContentEncoding.Base64) {
+            return String(Base64.getDecoder().decode(content), Charsets.UTF_8)
+        }
+        return content
+    }
+
+
+    actual fun readFile(pathComponent: PathComponent, encoding: ContentEncoding): String? {
+        val path = pathComponent.component ?: return null
+        return readFile(path, encoding)
+    }
+
+    private fun writeFile(path: String, contents: String, create: Boolean, encoding: ContentEncoding, append: Boolean = false): Boolean {
+        val file = File(path).canonicalFile
+        if (!file.exists()) {
+            if (!create) return false
+            file.createNewFile()
+        }
+
+        val finalContent: String
+        val appendToFile: Boolean
+
+        if (encoding == ContentEncoding.Base64) {
+            val sourceString = if (append) (readFile(path, ContentEncoding.Base64) ?: "") + contents else contents
+
+            finalContent = Base64.getEncoder().encodeToString(sourceString.toByteArray(Charsets.UTF_8))
+            appendToFile = false
+
+        } else {
+            finalContent = contents
+            appendToFile = append
+        }
+
+        val charset = {
+            when (encoding) {
+                ContentEncoding.Ascii -> Charsets.US_ASCII
+                else -> Charsets.UTF_8
+            }
+        }()
+        val bufferedWriter = BufferedWriter(OutputStreamWriter(FileOutputStream(file, appendToFile), charset))
+        bufferedWriter.write(finalContent)
+        bufferedWriter.close()
+        return true
+    }
+
+
+    actual fun writeFile(path: String, contents: String, create: Boolean, encoding: ContentEncoding): Boolean {
+        return writeFile(path, contents, create, encoding, false)
+    }
+
+
+    actual fun writeFile(pathComponent: PathComponent, contents: String, create: Boolean, encoding: ContentEncoding): Boolean {
+        val path = pathComponent.component ?: return false
+        return writeFile(path, contents, create, encoding, false)
+    }
+
+
+    actual fun appendFile(path: String, contents: String, create: Boolean, encoding: ContentEncoding): Boolean {
+        return writeFile(path, contents, create, encoding, true)
+    }
+
+
+    actual fun appendFile(pathComponent: PathComponent, contents: String, create: Boolean, encoding: ContentEncoding): Boolean {
+        val path = pathComponent.component ?: return false
+        return writeFile(path, contents, create, encoding, true)
+    }
+
+
+    actual fun touch(path: String): Boolean {
+        val file = File(path).canonicalFile
+        return file.createNewFile()
+    }
+
+
+    actual fun touch(pathComponent: PathComponent): Boolean {
+        val path = pathComponent.component ?: return false
+        return touch(path)
+    }
+
+
+    actual fun mkdir(path: String, recursive: Boolean): Boolean {
+        val file = File(path).canonicalFile
+        return if (recursive) file.mkdirs() else file.mkdir()
+    }
+
+
+    actual fun mkdir(pathComponent: PathComponent, recursive: Boolean): Boolean {
+        val path = pathComponent.component ?: return false
+        return mkdir(path, recursive)
+    }
+
+
+    actual fun exists(path: String): Boolean {
+        return File(path).canonicalFile.exists()
+    }
+
+
+    actual fun exists(pathComponent: PathComponent): Boolean {
+        val path = pathComponent.component ?: return false
+        return exists(path)
+    }
+
+
+    actual fun unlink(path: String): Boolean {
+        return File(path).canonicalFile.deleteRecursively()
+    }
+
+
+    actual fun unlink(pathComponent: PathComponent): Boolean {
+        val path = pathComponent.component ?: return false
+        return unlink(path)
+    }
+
+
+    actual fun moveFile(srcPath: String, destPath: String): Boolean {
+        val srcFile = File(srcPath).canonicalFile
+        val destFile = File(destPath).canonicalFile
+        return srcFile.renameTo(destFile)
+    }
+
+
+    actual fun moveFile(srcPathComponent: PathComponent, destPathComponent: PathComponent): Boolean {
+        val srcPath = srcPathComponent.component ?: return false
+        val destPath = destPathComponent.component ?: return false
+        return moveFile(srcPath, destPath)
+    }
+
+
+    actual fun copyFile(srcPath: String, destPath: String): Boolean {
+        val srcFile = File(srcPath).canonicalFile
+        val destFile = File(destPath).canonicalFile
+        return srcFile.copyRecursively(destFile, true)
+    }
+
+
+    actual fun copyFile(srcPathComponent: PathComponent, destPathComponent: PathComponent): Boolean {
+        val srcPath = srcPathComponent.component ?: return false
+        val destPath = destPathComponent.component ?: return false
+        return copyFile(srcPath, destPath)
+    }
+
+    actual fun readFileAsByteArray(path: String): ByteArray? {
+        val file = File(path).canonicalFile
+        return file.readBytes()
+    }
+
+}

--- a/fs-core/src/jvmMain/kotlin/com/suparnatural/core/fs/Path.kt
+++ b/fs-core/src/jvmMain/kotlin/com/suparnatural/core/fs/Path.kt
@@ -1,0 +1,56 @@
+package com.suparnatural.core.fs
+
+import java.io.File
+import java.nio.file.Paths
+
+/**
+ * Represents a file system path to a resource
+ */
+actual class Path actual constructor() {
+
+    constructor(absolutePath: String?, relativePath: String?): this() {
+        this.absolutePath = PathComponent(absolutePath)
+        this.relativePath = PathComponent(relativePath)
+    }
+
+    /**
+     * Absolute path to the resource
+     */
+    actual var absolutePath: PathComponent? = null
+    /**
+     * Relative Path to the resource
+     */
+    actual var relativePath: PathComponent? = null
+
+    actual companion object {
+
+        val Empty = Path()
+
+        /**
+         * Creates a new [Path] with the given [path] argument.
+         * [path] is copied to both absolute and relative path components.
+         */
+        actual fun simplified(path: String): Path = Path(path, path)
+    }
+
+}
+
+/**
+ * A [Path] is made up of [PathComponent]s. For example, a path has [Path.absolutePath] and [Path.relativePath] which are both [PathComponent]s.
+ */
+actual class PathComponent actual constructor(actual val component: String?) {
+    private val file = if (component != null) File(component).canonicalFile else null
+
+    override fun toString(): String {
+        return "[component=$component, canonicalPath=${file?.canonicalPath}, absolutePath=${file?.absolutePath}]"
+    }
+
+    /**
+     * Create a new [PathComponent] by appending [component] string.
+     */
+    actual fun byAppending(component: String): PathComponent? {
+        if (file == null) return null
+        return PathComponent(File(file.absolutePath, component).canonicalFile.absolutePath)
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,6 @@ pluginManagement {
 }
 
 rootProject.name = 'suparnatural-kotlin-multiplatform'
-include 'graphql-core', 'threading-core', 'cache-core', 'utilities-core', 'fs-core'
+include 'threading-core', 'cache-core', 'utilities-core', 'fs-core'
 
 enableFeaturePreview('GRADLE_METADATA')

--- a/utilities-core/src/androidMain/AndroidManifest.xml
+++ b/utilities-core/src/androidMain/AndroidManifest.xml
@@ -1,5 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.suparnatural.core.utilities">
-
-</manifest>
+<manifest package="com.suparnatural.core.utilities"/>


### PR DESCRIPTION
Hi,
this is just a draft. I wanted to hear what you think about it.

To support junit tests running on my development machine (not on ios- or android devices) I added a jvm target. Mainly copied from the android source.

I added a `readFileAsByteArray` method which allows to read a file into a ByteArray. This was necessary for me in my app because I am handling several small binary files, which are not BASE64 encoded.

What do you think? Would it make sense to integrate it in the main repo? If yes I could add tests and clean up.

Best Regards :)